### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ DBConnectURL = "postgres://engineuser:password@quotient_database:5432/engine"
 BindAddress = "0.0.0.0"
 ```
 
-The "DBConnectURL" will use values you popualte in the `.env` file. The `BindAddress` is the IP address the scoring engine will bind to. If you are deploying in the Docker container, this can be set to `0.0.0.0`.
+The "DBConnectURL" will use values you populate in the `.env` file. The `BindAddress` is the IP address the scoring engine will bind to. If you are deploying in the Docker container, this can be set to `0.0.0.0`.
 
 #### Ldap Settings
 


### PR DESCRIPTION
## Summary
- fix misspelling in README (`popualte` -> `populate`)

## Testing
- `go test ./...` *(fails: toolchain download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684461be7ce8832a9c454eb145fd9593