### PR TITLE
Fix ping count respect

### DIFF
--- a/engine/checks/ping.go
+++ b/engine/checks/ping.go
@@ -26,7 +26,7 @@ func (c Ping) Run(teamID uint, teamIdentifier string, roundID uint, resultsChan 
 		}
 
 		// Send ping
-		pinger.Count = 1
+		pinger.Count = c.Count
 		pinger.Timeout = 5 * time.Second
 		pinger.SetPrivileged(true)
 		err = pinger.Run()


### PR DESCRIPTION
## Summary
- use the configured ping count when running Ping checks
- removed the `ping_test.go` file to comply with instructions

## Testing
- `go test ./...` *(fails: downloading go toolchain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684461c8ffd8832aa31744101f21b7e1