### PR TITLE
Add documentation for custom checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ ip = "10.100.1_.2"
 
 Custom checks can be added to the `./custom-checks/` directory. It is very common to make the custom check simply run some other script that you have written that has the necessary logic to check the service. The script should return a 0 if the service is up and anything else if it is down. The script should be executable. The script will be mounted in the `/app/checks/` directory of the runner. If the script invokes external dependencies or needs to have a specific run time, this should be added to the Dockerfile.runner and the runner rebuilt and redeployed.
 
+For a detailed walkthrough of writing custom checks, see [docs/custom-checks.md](docs/custom-checks.md).
+
 ## Contributing
 
 Please fork the repository and submit a pull request. For major changes, please open an issue first to discuss what you would like to change.

--- a/docs/custom-checks.md
+++ b/docs/custom-checks.md
@@ -1,0 +1,56 @@
+# Writing Custom Score Checks
+
+This guide explains how to create and run your own service checks. Custom checks are shell scripts or binaries executed by the runner container. They return an exit status of `0` when the service is considered up and non–zero when it is down.
+
+## Command Format
+
+Custom checks are defined under a `[[box.custom]]` section in `event.conf`. The `command` field contains the command to run. The runner replaces placeholders before executing the command:
+
+- `ROUND` – the current round number
+- `TARGET` – hostname or IP address for the service
+- `TEAMIDENTIFIER` – the team's unique identifier
+- `USERNAME` – a username pulled from any configured credlists
+- `PASSWORD` – the corresponding password
+
+Example configuration:
+
+```toml
+[[box.custom]]
+command = "/app/checks/example.sh ROUND TARGET TEAMIDENTIFIER USERNAME PASSWORD"
+credlists = ["web01.credlist", "users.credlist"]
+regex = "example [Tt]ext"
+```
+
+The runner mounts the contents of `./custom-checks` at `/app/checks/` inside the container. Place your script in that directory and ensure it is executable.
+
+## Writing the Script
+
+A simple shell script might look like:
+
+```sh
+#!/bin/sh
+# Usage: ./example.sh <round> <address> <team_id> <username> <password>
+ROUND="$1"
+ADDRESS="$2"
+TEAM_ID="$3"
+USERNAME="$4"
+PASSWORD="$5"
+
+# Implement your logic here
+ping -c2 -W2 -w2 "$ADDRESS" && exit 0
+exit 1
+```
+
+Your script can print output to stdout or stderr to help with debugging. This output is captured and visible from the admin interface when a check fails.
+
+## Environment and Dependencies
+
+Runner containers are built from `Dockerfile.runner`. Python dependencies can be listed in `custom-checks/requirements.txt`. Additional packages may be installed by editing `Dockerfile.runner` and rebuilding the runner with `docker-compose build runner`.
+
+## Recommendations
+
+- Keep the check fast. Rounds may have short timeouts (default is 15 s).
+- Avoid infinite loops. The runner will forcibly stop the command when the timeout is reached.
+- Log helpful details on failure to ease troubleshooting.
+
+For more advanced examples, see `custom-checks/example.sh` in this repository.


### PR DESCRIPTION
## Summary
- document how to create and run custom score checks
- link to the documentation from the README

## Testing
- `go vet ./...` *(fails: Forbidden download)*

------
https://chatgpt.com/codex/tasks/task_e_684464b29fa0832ab7f104e1d4f40d9f