### PR TITLE
Fix hash computation and remove extra SMTP diff

### DIFF
--- a/engine/checks/helpers.go
+++ b/engine/checks/helpers.go
@@ -33,11 +33,12 @@ func FileHash(fileName string) (string, error) {
 // StringHash returns the sha256sum of the string
 func StringHash(fileContent string) (string, error) {
 	hasher := sha256.New()
-	_, err := hasher.Write([]byte(fileContent))
-	if err != nil {
+	if _, err := hasher.Write([]byte(fileContent)); err != nil {
 		return "", err
 	}
-	return hexEncode(string(hasher.Sum(nil))), nil
+	// Directly encode the byte slice returned by hasher.Sum to avoid
+	// corrupting non-UTF8 bytes when converting to and from strings.
+	return hex.EncodeToString(hasher.Sum(nil)), nil
 }
 
 func GetFile(fileName string) (string, error) {
@@ -50,8 +51,4 @@ func GetFile(fileName string) (string, error) {
 		return "", err
 	}
 	return string(fileContent), nil
-}
-
-func hexEncode(inputString string) string {
-	return hex.EncodeToString([]byte(inputString))
 }

--- a/engine/checks/smtp.go
+++ b/engine/checks/smtp.go
@@ -165,8 +165,9 @@ func (c Smtp) Run(teamID uint, teamIdentifier string, roundID uint, resultsChan 
 
 		body := fmt.Sprintf("Subject: %s\n\n%s\n\n", subject, fortune)
 
-		// Write the body
-		_, err = fmt.Fprintf(wc, body)
+		// Write the body using Fprint to avoid treating the contents as a
+		// format string.
+		_, err = fmt.Fprint(wc, body)
 		if err != nil {
 			checkResult.Error = "writing body failed"
 			checkResult.Debug = err.Error()


### PR DESCRIPTION
## Summary
- fix SHA-256 helper not to corrupt bytes when hex-encoding
- simplify SMTP comment and keep fmt.Fprint usage

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6844658d0cc4832ab5a26935b809b024