### PR TITLE
Fix SQL check result handling

### DIFF
--- a/engine/checks/sql.go
+++ b/engine/checks/sql.go
@@ -61,6 +61,7 @@ func (c Sql) Run(teamID uint, teamIdentifier string, roundID uint, resultsChan c
 			checkResult.Debug = "no query command, only checking connection. creds used were " + username + ":" + password
 			checkResult.Status = true
 			response <- checkResult
+			return
 		}
 
 		rows, err = db.QueryContext(context.TODO(), q.Command)
@@ -90,13 +91,14 @@ func (c Sql) Run(teamID uint, teamIdentifier string, roundID uint, resultsChan c
 						checkResult.Status = true
 						checkResult.Debug = "found regex match: " + output + ". creds used were " + username + ":" + password
 						response <- checkResult
+						return
 					}
 				} else {
 					if strings.TrimSpace(output) == q.Output {
 						checkResult.Status = true
 						checkResult.Debug = "found exact string match: " + output + ".creds used were " + username + ":" + password
 						response <- checkResult
-						break
+						return
 					}
 				}
 			}


### PR DESCRIPTION
## Summary
- prevent SQL check from continuing after a successful match by returning immediately

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6844771555d0832abed308ea399a35a6