### PR TITLE
Add scheduled scoring start time

### DIFF
--- a/config/event.conf.example
+++ b/config/event.conf.example
@@ -9,8 +9,9 @@
   ShowDebugToBlueTeam = false
   LogoImage = "/static/assets/quotient.svg"
   StartPaused = true
-  # Set the engine start time in RFC3339 format
+  # Set the engine start and stop time in RFC3339 format
   # StartTime = "2025-01-02T15:04:05Z"
+  # StopTime = "2025-01-03T15:04:05Z"
   Delay = 30
   Jitter = 5
   Points = 1

--- a/config/event.conf.example
+++ b/config/event.conf.example
@@ -9,6 +9,8 @@
   ShowDebugToBlueTeam = false
   LogoImage = "/static/assets/quotient.svg"
   StartPaused = true
+  # Set the engine start time in RFC3339 format
+  # StartTime = "2025-01-02T15:04:05Z"
   Delay = 30
   Jitter = 5
   Points = 1

--- a/engine/config/config.go
+++ b/engine/config/config.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/BurntSushi/toml"
 )
@@ -82,6 +83,7 @@ type MiscConfig struct {
 	LogFile             string
 
 	StartPaused bool
+	StartTime   time.Time
 
 	// Round settings
 	Delay  int

--- a/engine/config/config.go
+++ b/engine/config/config.go
@@ -84,6 +84,7 @@ type MiscConfig struct {
 
 	StartPaused bool
 	StartTime   time.Time
+	StopTime    time.Time
 
 	// Round settings
 	Delay  int

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -99,6 +99,15 @@ func (se *ScoringEngine) Start() {
 
 	se.NextRoundStartTime = time.Time{}
 
+	if se.CurrentRound == 1 && !se.Config.MiscSettings.StartTime.IsZero() {
+		wait := time.Until(se.Config.MiscSettings.StartTime)
+		if wait > 0 {
+			slog.Info("Waiting for engine start time", "start_time", se.Config.MiscSettings.StartTime)
+			se.NextRoundStartTime = se.Config.MiscSettings.StartTime
+			time.Sleep(wait)
+		}
+	}
+
 	redisAddr := os.Getenv("REDIS_ADDR")
 	if redisAddr == "" {
 		redisAddr = "quotient_redis:6379"

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -108,6 +108,18 @@ func (se *ScoringEngine) Start() {
 		}
 	}
 
+	if !se.Config.MiscSettings.StopTime.IsZero() {
+		go func(stop time.Time) {
+			wait := time.Until(stop)
+			if wait > 0 {
+				slog.Info("Engine stop time scheduled", "stop_time", stop)
+				time.Sleep(wait)
+			}
+			slog.Info("Pausing engine at stop time", "stop_time", stop)
+			se.PauseEngine()
+		}(se.Config.MiscSettings.StopTime)
+	}
+
 	redisAddr := os.Getenv("REDIS_ADDR")
 	if redisAddr == "" {
 		redisAddr = "quotient_redis:6379"
@@ -320,6 +332,16 @@ func (se *ScoringEngine) ResetScores() error {
 	slog.Info("Scores reset and Redis queues cleared successfully")
 
 	return nil
+}
+
+// SetStartTime updates the engine start time at runtime.
+func (se *ScoringEngine) SetStartTime(t time.Time) {
+	se.Config.MiscSettings.StartTime = t
+}
+
+// SetStopTime updates the engine stop time at runtime.
+func (se *ScoringEngine) SetStopTime(t time.Time) {
+	se.Config.MiscSettings.StopTime = t
 }
 
 // perform a round of koth

--- a/static/templates/pages/admin/engine.html
+++ b/static/templates/pages/admin/engine.html
@@ -11,10 +11,29 @@
                     </div>
                 </div>
                 <div class="row mb-3">
+                    <div class="col-6">
+                        <label for="startTimeInput" class="form-label">Start Time</label>
+                        <input type="datetime-local" id="startTimeInput" class="form-control" />
+                    </div>
+                    <div class="col-6 d-flex align-items-end">
+                        <button id="setStartTimeButton" class="btn btn-primary rounded-0">Update Start Time</button>
+                    </div>
+                </div>
+                <div class="row mb-3">
+                    <div class="col-6">
+                        <label for="stopTimeInput" class="form-label">Stop Time</label>
+                        <input type="datetime-local" id="stopTimeInput" class="form-control" />
+                    </div>
+                    <div class="col-6 d-flex align-items-end">
+                        <button id="setStopTimeButton" class="btn btn-primary rounded-0">Update Stop Time</button>
+                    </div>
+                </div>
+                <div class="row mb-3">
                     <div class="col">
                         <h3>Round Progress</h3>
                         <p id="round__number"></p>
                         <p id="engine__status" class="fw-bold"></p>
+                        <p id="engine__stop_status" class="fw-bold"></p>
                         <div class="progress">
                             <div id="roundProgress"
                                 class="progress-bar progress-bar-striped progress-bar-animated bg-success"
@@ -51,10 +70,18 @@
                 <script>
                     const PROGRESS = document.getElementById('roundProgress');
                     const ENGINE_STATUS = document.getElementById('engine__status');
+<<<<<<< ours
+=======
+                    const ENGINE_STOP_STATUS = document.getElementById('engine__stop_status');
+>>>>>>> theirs
                     let LASTROUND = 0;
                     let CURRENTROUND = 0;
                     let NEXTROUND = 0;
                     let STARTTIME = 0;
+<<<<<<< ours
+=======
+                    let STOPTIME = 0;
+>>>>>>> theirs
                     let RUNNING = false;
 
                     document.getElementById('pauseButton').addEventListener('click', () => {
@@ -86,6 +113,32 @@
                                 });
                         }
                     });
+                    document.getElementById('setStartTimeButton').addEventListener('click', () => {
+                        const val = document.getElementById('startTimeInput').value;
+                        if (!val) { return; }
+                        const iso = new Date(val).toISOString();
+                        fetch('/api/engine/starttime', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ start_time: iso }),
+                        })
+                            .then(response => response.json())
+                            .then(() => { window.location.reload(); })
+                            .catch(error => console.error('Error setting start time:', error));
+                    });
+                    document.getElementById('setStopTimeButton').addEventListener('click', () => {
+                        const val = document.getElementById('stopTimeInput').value;
+                        if (!val) { return; }
+                        const iso = new Date(val).toISOString();
+                        fetch('/api/engine/stoptime', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ stop_time: iso }),
+                        })
+                            .then(response => response.json())
+                            .then(() => { window.location.reload(); })
+                            .catch(error => console.error('Error setting stop time:', error));
+                    });
                     function getEngineData() {
                         fetch('/api/engine')
                             .then(response => response.json())
@@ -94,7 +147,18 @@
                                 CURRENTROUND = data["current_round_time"];
                                 NEXTROUND = data["next_round_time"];
                                 STARTTIME = data["start_time"];
+<<<<<<< ours
+=======
+                                STOPTIME = data["stop_time"];
+>>>>>>> theirs
                                 RUNNING = data["running"];
+
+                                if (STARTTIME) {
+                                    document.getElementById('startTimeInput').value = new Date(STARTTIME).toISOString().slice(0,16);
+                                }
+                                if (STOPTIME) {
+                                    document.getElementById('stopTimeInput').value = new Date(STOPTIME).toISOString().slice(0,16);
+                                }
 
                                 let last_round_start_time = new Date(LASTROUND.StartTime).toLocaleString();
                                 let current_round_time = new Date(CURRENTROUND).toLocaleString();
@@ -104,6 +168,14 @@
                                 } else {
                                     ENGINE_STATUS.textContent = '';
                                 }
+<<<<<<< ours
+=======
+                                if (STOPTIME && Date.now() < new Date(STOPTIME)) {
+                                    ENGINE_STOP_STATUS.textContent = `Engine will stop at ${new Date(STOPTIME).toLocaleString()}`;
+                                } else {
+                                    ENGINE_STOP_STATUS.textContent = '';
+                                }
+>>>>>>> theirs
 
                                 document.getElementById('round__number').textContent = `Round ${LASTROUND.ID} was at ${last_round_start_time}.
                                 Round ${LASTROUND.ID + 1} started at ${current_round_time} and should end at ${next_round_time}.`;
@@ -152,6 +224,15 @@
                         } else {
                             ENGINE_STATUS.textContent = '';
                         }
+<<<<<<< ours
+=======
+                        if (STOPTIME && Date.now() < new Date(STOPTIME)) {
+                            const diff = Math.ceil((new Date(STOPTIME) - Date.now()) / 1000);
+                            ENGINE_STOP_STATUS.textContent = `Engine will stop in ${diff}s`;
+                        } else {
+                            ENGINE_STOP_STATUS.textContent = '';
+                        }
+>>>>>>> theirs
                     }
 
                     getEngineData()

--- a/static/templates/pages/admin/engine.html
+++ b/static/templates/pages/admin/engine.html
@@ -70,18 +70,12 @@
                 <script>
                     const PROGRESS = document.getElementById('roundProgress');
                     const ENGINE_STATUS = document.getElementById('engine__status');
-<<<<<<< ours
-=======
                     const ENGINE_STOP_STATUS = document.getElementById('engine__stop_status');
->>>>>>> theirs
                     let LASTROUND = 0;
                     let CURRENTROUND = 0;
                     let NEXTROUND = 0;
                     let STARTTIME = 0;
-<<<<<<< ours
-=======
                     let STOPTIME = 0;
->>>>>>> theirs
                     let RUNNING = false;
 
                     document.getElementById('pauseButton').addEventListener('click', () => {
@@ -147,10 +141,7 @@
                                 CURRENTROUND = data["current_round_time"];
                                 NEXTROUND = data["next_round_time"];
                                 STARTTIME = data["start_time"];
-<<<<<<< ours
-=======
                                 STOPTIME = data["stop_time"];
->>>>>>> theirs
                                 RUNNING = data["running"];
 
                                 if (STARTTIME) {
@@ -168,14 +159,11 @@
                                 } else {
                                     ENGINE_STATUS.textContent = '';
                                 }
-<<<<<<< ours
-=======
                                 if (STOPTIME && Date.now() < new Date(STOPTIME)) {
                                     ENGINE_STOP_STATUS.textContent = `Engine will stop at ${new Date(STOPTIME).toLocaleString()}`;
                                 } else {
                                     ENGINE_STOP_STATUS.textContent = '';
                                 }
->>>>>>> theirs
 
                                 document.getElementById('round__number').textContent = `Round ${LASTROUND.ID} was at ${last_round_start_time}.
                                 Round ${LASTROUND.ID + 1} started at ${current_round_time} and should end at ${next_round_time}.`;
@@ -224,15 +212,12 @@
                         } else {
                             ENGINE_STATUS.textContent = '';
                         }
-<<<<<<< ours
-=======
                         if (STOPTIME && Date.now() < new Date(STOPTIME)) {
                             const diff = Math.ceil((new Date(STOPTIME) - Date.now()) / 1000);
                             ENGINE_STOP_STATUS.textContent = `Engine will stop in ${diff}s`;
                         } else {
                             ENGINE_STOP_STATUS.textContent = '';
                         }
->>>>>>> theirs
                     }
 
                     getEngineData()

--- a/static/templates/pages/admin/engine.html
+++ b/static/templates/pages/admin/engine.html
@@ -14,6 +14,7 @@
                     <div class="col">
                         <h3>Round Progress</h3>
                         <p id="round__number"></p>
+                        <p id="engine__status" class="fw-bold"></p>
                         <div class="progress">
                             <div id="roundProgress"
                                 class="progress-bar progress-bar-striped progress-bar-animated bg-success"
@@ -49,9 +50,11 @@
                 </div>
                 <script>
                     const PROGRESS = document.getElementById('roundProgress');
+                    const ENGINE_STATUS = document.getElementById('engine__status');
                     let LASTROUND = 0;
                     let CURRENTROUND = 0;
                     let NEXTROUND = 0;
+                    let STARTTIME = 0;
                     let RUNNING = false;
 
                     document.getElementById('pauseButton').addEventListener('click', () => {
@@ -90,11 +93,17 @@
                                 LASTROUND = data["last_round"];
                                 CURRENTROUND = data["current_round_time"];
                                 NEXTROUND = data["next_round_time"];
+                                STARTTIME = data["start_time"];
                                 RUNNING = data["running"];
 
                                 let last_round_start_time = new Date(LASTROUND.StartTime).toLocaleString();
                                 let current_round_time = new Date(CURRENTROUND).toLocaleString();
                                 let next_round_time = new Date(NEXTROUND).toLocaleString();
+                                if (STARTTIME && Date.now() < new Date(STARTTIME)) {
+                                    ENGINE_STATUS.textContent = `Engine will start at ${new Date(STARTTIME).toLocaleString()}`;
+                                } else {
+                                    ENGINE_STATUS.textContent = '';
+                                }
 
                                 document.getElementById('round__number').textContent = `Round ${LASTROUND.ID} was at ${last_round_start_time}.
                                 Round ${LASTROUND.ID + 1} started at ${current_round_time} and should end at ${next_round_time}.`;
@@ -136,11 +145,21 @@
                         PROGRESS.setAttribute('aria-valuenow', progress);
                     }
 
+                    function updateStatus() {
+                        if (STARTTIME && Date.now() < new Date(STARTTIME)) {
+                            const diff = Math.ceil((new Date(STARTTIME) - Date.now()) / 1000);
+                            ENGINE_STATUS.textContent = `Engine will start in ${diff}s`;
+                        } else {
+                            ENGINE_STATUS.textContent = '';
+                        }
+                    }
+
                     getEngineData()
                     updateProgress()
+                    updateStatus()
 
                     // update every second
-                    setInterval(updateProgress, 1000);
+                    setInterval(() => { updateProgress(); updateStatus(); }, 1000);
                 </script>
             </div>
         </div>

--- a/www/api/admin.go
+++ b/www/api/admin.go
@@ -109,6 +109,7 @@ func GetEngine(w http.ResponseWriter, r *http.Request) {
 		"last_round":         lastRound,
 		"current_round_time": eng.CurrentRoundStartTime,
 		"next_round_time":    eng.NextRoundStartTime,
+		"start_time":         eng.Config.MiscSettings.StartTime,
 		"running":            !eng.IsEnginePaused,
 	})
 	w.Write(d)

--- a/www/api/admin.go
+++ b/www/api/admin.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"time"
+
 	"quotient/engine/db"
 )
 
@@ -110,6 +112,7 @@ func GetEngine(w http.ResponseWriter, r *http.Request) {
 		"current_round_time": eng.CurrentRoundStartTime,
 		"next_round_time":    eng.NextRoundStartTime,
 		"start_time":         eng.Config.MiscSettings.StartTime,
+		"stop_time":          eng.Config.MiscSettings.StopTime,
 		"running":            !eng.IsEnginePaused,
 	})
 	w.Write(d)
@@ -136,6 +139,52 @@ func UpdateTeams(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+
+	d := []byte(`{"status": "success"}`)
+	w.Write(d)
+}
+
+func UpdateStartTime(w http.ResponseWriter, r *http.Request) {
+	type Form struct {
+		StartTime string `json:"start_time"`
+	}
+
+	var form Form
+	if err := json.NewDecoder(r.Body).Decode(&form); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	t, err := time.Parse(time.RFC3339, form.StartTime)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	eng.SetStartTime(t)
+
+	d := []byte(`{"status": "success"}`)
+	w.Write(d)
+}
+
+func UpdateStopTime(w http.ResponseWriter, r *http.Request) {
+	type Form struct {
+		StopTime string `json:"stop_time"`
+	}
+
+	var form Form
+	if err := json.NewDecoder(r.Body).Decode(&form); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	t, err := time.Parse(time.RFC3339, form.StopTime)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	eng.SetStopTime(t)
 
 	d := []byte(`{"status": "success"}`)
 	w.Write(d)

--- a/www/router.go
+++ b/www/router.go
@@ -146,6 +146,8 @@ func (router *Router) Start() {
 	mux.HandleFunc("GET /api/engine/reset", ADMINAUTH(api.ResetScores))
 	mux.HandleFunc("GET /api/engine", ADMINAUTH(api.GetEngine))
 	mux.HandleFunc("GET /api/engine/tasks", ADMINAUTH(api.GetActiveTasks))
+	mux.HandleFunc("POST /api/engine/starttime", ADMINAUTH(api.UpdateStartTime))
+	mux.HandleFunc("POST /api/engine/stoptime", ADMINAUTH(api.UpdateStopTime))
 	mux.HandleFunc("POST /api/admin/teams", ADMINAUTH(api.UpdateTeams))
 
 	mux.HandleFunc("GET /api/engine/export/scores", ADMINAUTH(api.ExportScores))


### PR DESCRIPTION
## Summary
- allow engines to start scoring at a specific time
- expose start time in admin API and wait for it in engine
- show upcoming start time countdown in the admin UI
- document new `StartTime` setting in example config

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6844bc0e6fa4832ab28fd577c1d994f9