### PR TITLE
Fix credlist path lookup

### DIFF
--- a/config/event.conf.example
+++ b/config/event.conf.example
@@ -21,6 +21,10 @@
     CredlistName = "Users"
     CredlistPath = "users.credlist"
     CredlistExplainText = "username,password"
+  [[CredlistSettings.Credlist]]
+    CredlistName = "Admins"
+    CredlistPath = "admins.credlist"
+    CredlistExplainText = "username,password"
 
 [[Admin]]
   Name = "admin"
@@ -52,7 +56,7 @@
 
   [[Box.Custom]]
     Display = "cassandra"
-    CredLists = ["users.credlist"]
+    CredLists = ["Users", "Admins"]
     Command = "/app/checks/example.sh ROUND TARGET TEAMIDENTIFIER USERNAME PASSWORD"
 
 [[Box]]
@@ -61,7 +65,7 @@
 
   [[Box.Smtp]]
     Display = "marpessa"
-    CredLists = ["users.credlist"]
+    CredLists = ["Users"]
 
   [[Box.Tcp]]
     Port = 4444

--- a/engine/checks/checks.go
+++ b/engine/checks/checks.go
@@ -74,6 +74,10 @@ func (service *Service) GetCredlists() []string {
 	return service.CredLists
 }
 
+func (service *Service) SetCredlists(lists []string) {
+	service.CredLists = lists
+}
+
 func (service *Service) getCreds(teamID uint) (string, string, error) {
 	// check if credlists are defined, if not return error
 	if len(service.CredLists) == 0 {

--- a/engine/config/config.go
+++ b/engine/config/config.go
@@ -293,14 +293,14 @@ func checkConfig(conf *ConfigSettings) error {
 
 	// check for duplicate box names
 	dupeBoxMap := make(map[string]bool)
-       runnerNames := make(map[string]bool)
+	runnerNames := make(map[string]bool)
 
-       // build a map of credlist names to file paths for quick lookup
-       credMap := map[string]string{}
-       for _, cl := range conf.CredlistSettings.Credlist {
-               credMap[cl.CredlistName] = cl.CredlistPath
-               credMap[cl.CredlistPath] = cl.CredlistPath
-       }
+	// build a map of credlist names to file paths for quick lookup
+	credMap := map[string]string{}
+	for _, cl := range conf.CredlistSettings.Credlist {
+		credMap[cl.CredlistName] = cl.CredlistPath
+		credMap[cl.CredlistPath] = cl.CredlistPath
+	}
 
 	// ACTUALLY DO CHECKS FOR BOX AND SERVICE CONFIGURATION
 	for i := range conf.Box {
@@ -327,8 +327,8 @@ func checkConfig(conf *ConfigSettings) error {
 			getRunners(conf.Box[i].Smb), getRunners(conf.Box[i].Smtp), getRunners(conf.Box[i].Sql), getRunners(conf.Box[i].Ssh),
 			getRunners(conf.Box[i].Tcp), getRunners(conf.Box[i].Vnc), getRunners(conf.Box[i].Web), getRunners(conf.Box[i].WinRM),
 		}
-               for _, checks := range checkSets {
-                       for _, check := range checks {
+		for _, checks := range checkSets {
+			for _, check := range checks {
 				if err := check.Verify(
 					conf.Box[i].Name,
 					conf.Box[i].IP,
@@ -345,15 +345,15 @@ func checkConfig(conf *ConfigSettings) error {
 					runnerNames[check.GetName()] = true
 				}
 
-                               // translate credlist names to their file paths
-                               credPaths := make([]string, 0, len(check.GetCredlists()))
-                               for _, list := range check.GetCredlists() {
-                                       if path, ok := credMap[list]; ok {
-                                               credPaths = append(credPaths, path)
-                                       } else {
-                                               errResult = errors.Join(errResult, fmt.Errorf("credlist not found for %s", check.GetName()))
-                                       }
-                               }
+				// translate credlist names to their file paths
+				credPaths := make([]string, 0, len(check.GetCredlists()))
+				for _, list := range check.GetCredlists() {
+					if path, ok := credMap[list]; ok {
+						credPaths = append(credPaths, path)
+					} else {
+						errResult = errors.Join(errResult, fmt.Errorf("credlist not found for %s", check.GetName()))
+					}
+				}
 				if setter, ok := check.(interface{ SetCredlists([]string) }); ok && len(credPaths) > 0 {
 					setter.SetCredlists(credPaths)
 				}


### PR DESCRIPTION
## Summary
- map credlist names to file paths once during config validation
- update services with the mapped paths using `SetCredlists`

## Testing
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6846050c087c832aa5d6f4c1ab282d18